### PR TITLE
Support non-linear migration plans

### DIFF
--- a/drifter-postgresql.cabal
+++ b/drifter-postgresql.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:   Drifter.PostgreSQL
   build-depends:       base >=4.5 && <5
                      , postgresql-simple >= 0.2
+                     , containers
                      , drifter >= 0.2
                      , time
                      , either


### PR DESCRIPTION
In order to reuse the Drifter machinery, we capture the state of the database schema
and thread that through the whole migration process. Drifter's `migrate` function
will order the changes by dependency and then run the migration process from the
very beginning. This is ideal, but we need a way to prevent existing migrations from
being recommitted. This change threads the names of all previous migrations through
the migration process allowing migrate to skip any migrations that are already
done.

This likely needs tests. This would replace #2 if you chose to use it.