### PR TITLE
Update package dependencies

### DIFF
--- a/drifter-postgresql.cabal
+++ b/drifter-postgresql.cabal
@@ -30,9 +30,9 @@ library
                      , containers
                      , drifter >= 0.2
                      , time
-                     , either
                      , mtl
                      , transformers
+                     , transformers-compat >=0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
`either` is unused.
You could either use `transformers-compat`, or add a lower bound to `transformers >= 0.4`.

I made the revision for the latest release adding lower bound to `transformers`. `transformers` bundled with GHC-7.8.4 is older, and by default the bundled one picked. https://hackage.haskell.org/package/drifter-postgresql-0.2.0/revisions/

I recommend either adding a CI for GHC-7.8, GHC-7.6 or bump `base >= 4.8` (GHC-7.10) lower bound. Don't lie in `tested-with`.

Note: i also made revisions for older releases, adding `either <5` bound.